### PR TITLE
Suppress permission errors from `vault list`

### DIFF
--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -30,7 +30,7 @@ function _vault() {
   elif [[ "$line" =~ ^vault\ (read|write|delete|list)\ (.*)$ ]]; then
     path=${BASH_REMATCH[2]}
     if [[ "$path" =~ ^([^ ]+)/([^ /]*)$ ]]; then
-      list=$(vault list ${BASH_REMATCH[1]} | tail -n +2)
+      list=$(vault list ${BASH_REMATCH[1]} 2> /dev/null | tail -n +2)
       COMPREPLY=($(compgen -W "$list" -P "${BASH_REMATCH[1]}/" -- ${BASH_REMATCH[2]}))
     else
       COMPREPLY=($(compgen -W "$VAULT_ROOTPATH" -- $path))


### PR DESCRIPTION
This prevents printing permission errors to the console when attempting
to tab complete a secret and user is not authenticated or otherwise
doesn't have access - e.g.:

```
$ vault list secret/<Tab>Error reading secret/: Error making API request.

URL: GET https://vault.service.n9.depot:8200/v1/secret/?list=true
Code: 403. Errors:

* permission denied
```

This also prevents the following error when there are no secrets stored yet:

```
$ vault list secret<Tab>/No value found at secret/
```