### PR TITLE
Enable completion for policies

### DIFF
--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -19,9 +19,13 @@ function _vault() {
   fi
 
   local cur=${COMP_WORDS[COMP_CWORD]}
+  local prev=${COMP_WORDS[COMP_CWORD-1]}
   local line=${COMP_LINE}
 
-  if [ "$(echo $line | wc -w)" -le 2 ]; then
+  if [[ $prev == "policies" || $prev == "policy-write" || $prev == "policy-delete" ]]; then
+    local policies=$(vault policies 2> /dev/null)
+    COMPREPLY=($(compgen -W "$policies" -- $cur))
+  elif [ "$(echo $line | wc -w)" -le 2 ]; then
     if [[ "$line" =~ ^vault\ (read|write|delete|list)\ $ ]]; then
       COMPREPLY=($(compgen -W "$VAULT_ROOTPATH" -- ''))
     else

--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -22,7 +22,7 @@ function _vault() {
   local prev=${COMP_WORDS[COMP_CWORD-1]}
   local line=${COMP_LINE}
 
-  if [[ $prev == "policies" || $prev == "policy-write" || $prev == "policy-delete" ]]; then
+  if [[ $prev =~ ^(policies|policy-write|policy-delete) ]]; then
     local policies=$(vault policies 2> /dev/null)
     COMPREPLY=($(compgen -W "$policies" -- $cur))
   elif [ "$(echo $line | wc -w)" -le 2 ]; then


### PR DESCRIPTION
e.g.:

```
$ vault policies <Tab><Tab>
ann                   commentsvc-owner      foosvc-owner          msgmxsvc
bastion               default               hadoop_edge           msgmxsvc-owner
benchmarksvc-owner    experimentsvc         hadoop_edge-owner     n9_bastion
benchmarksvc-service  experimentsvc-owner   librarysvc            root
commentsvc            foosvc                librarysvc-owner      shardsync

$ vault policies b<Tab><Tab>
bastion               benchmarksvc-owner    benchmarksvc-service
```