### PR TITLE
Make "secret" completion work w/ recent vault versions

### DIFF
--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -23,7 +23,7 @@ function _vault() {
   elif [[ "$line" =~ ^vault\ (read|write|delete|list)\ (.*)$ ]]; then
     path=${BASH_REMATCH[2]}
     if [[ "$path" =~ ^([^ ]+)/([^ /]*)$ ]]; then
-      list=$(vault list ${BASH_REMATCH[1]} | tail -n +2)
+      list=$(vault list -format=yaml ${BASH_REMATCH[1]} | awk '{ print $2 }')
       COMPREPLY=($(compgen -W "$list" -P "${BASH_REMATCH[1]}/" -- ${BASH_REMATCH[2]}))
     else
       COMPREPLY=($(compgen -W "$VAULT_ROOTPATH" -- $path))


### PR DESCRIPTION
Before:

```
$ vault version
Vault v0.6.2

$ vault list cubbyhole/<Tab><Tab>
cubbyhole/----  cubbyhole/test
```

It's getting confused because the output format of `vault list` changed
slightly in some recent Vault version (they added a line with `----`).

```
$ vault list cubbyhole/
Keys
----
test
```

This uses `vault list -format=yaml` which should be more stable.

```
$ vault list -format=yaml cubbyhole
- test
```

It works in older Vault versions too:

```
$ vault version
Vault v0.5.2

$ vault list -format=yaml cubbyhole/
- test
```