### PR TITLE
Simplify code for getting mounts list

### DIFF
--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -15,7 +15,7 @@ function _vault() {
     # we do not have access to list mounts
     local VAULT_ROOTPATH="secret"
   else
-    local VAULT_ROOTPATH=$(vault mounts | tail -n +2 | awk '{print $1}' | paste -s -d ' ' -)
+    local VAULT_ROOTPATH=$(vault mounts | awk 'NR > 1 {print $1}')
   fi
 
   local cur=${COMP_WORDS[COMP_CWORD]}

--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -6,24 +6,24 @@
 # see https://github.com/iljaweis/vault-bash-completion
 # ---------------------------------------------------------------------------
 
+function _vault_mounts() {
+  (
+    set -euo pipefail
+    if ! vault mounts 2> /dev/null | awk 'NR > 1 {print $1}'; then
+      echo "secret"
+    fi
+  )
+}
+
 function _vault() {
   local VAULT_COMMANDS='delete path-help read renew revoke server status write audit-disable audit-enable audit-list auth auth-disable auth-enable capabilities generate-root init key-status list mount mount-tune mounts policies policy-delete policy-write rekey remount rotate seal ssh step-down token-create token-lookup token-renew token-revoke unmount unseal version'
-
-  # get root paths
-  vault mounts >/dev/null 2>&1
-  if [ $? != 0 ]; then
-    # we do not have access to list mounts
-    local VAULT_ROOTPATH="secret"
-  else
-    local VAULT_ROOTPATH=$(vault mounts | awk 'NR > 1 {print $1}')
-  fi
 
   local cur=${COMP_WORDS[COMP_CWORD]}
   local line=${COMP_LINE}
 
   if [ "$(echo $line | wc -w)" -le 2 ]; then
     if [[ "$line" =~ ^vault\ (read|write|delete|list)\ $ ]]; then
-      COMPREPLY=($(compgen -W "$VAULT_ROOTPATH" -- ''))
+      COMPREPLY=($(compgen -W "$(_vault_mounts)" -- ''))
     else
       COMPREPLY=($(compgen -W "$VAULT_COMMANDS" -- $cur))
     fi
@@ -33,7 +33,7 @@ function _vault() {
       list=$(vault list ${BASH_REMATCH[1]} | tail -n +2)
       COMPREPLY=($(compgen -W "$list" -P "${BASH_REMATCH[1]}/" -- ${BASH_REMATCH[2]}))
     else
-      COMPREPLY=($(compgen -W "$VAULT_ROOTPATH" -- $path))
+      COMPREPLY=($(compgen -W "$(_vault_mounts)" -- $path))
     fi
   fi
 }


### PR DESCRIPTION
Use 2 commands instead of 4, so easier to read and a tad more efficient.

```
$ vault list <Tab>
cubbyhole/  secret/     sys/
```