### PR TITLE
Add tests for completing policies

### DIFF
--- a/tests/get_completions.bash
+++ b/tests/get_completions.bash
@@ -20,7 +20,7 @@ get_completions(){
     COMP_WORDS=("$@")
 
     # add '' to COMP_WORDS if the last character of the command line is a space
-    [[ ${COMP_LINE[@]: -1} = ' ' ]] && COMP_WORDS+=('')
+    [[ "${COMP_LINE[@]: -1}" = ' ' ]] && COMP_WORDS+=('')
 
     # index of the last word
     COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -87,3 +87,45 @@ fail() {
   output=$(echo "$output" | paste -s -d ' ' -)
   [[ "$output" =~ 'cubbyhole/test' ]] || fail "output was: \"$output\""
 }
+
+@test "'vault policies ' => default root" {
+  run get_completions 'vault policies '
+  [[ "$status" == 0 ]]
+  output=$(echo "$output" | paste -s -d ' ' -)
+  [[ "$output" =~ 'default root' ]] || fail "output was: \"$output\""
+}
+
+@test "'vault policies d' => default" {
+  run get_completions 'vault policies d'
+  [[ "$status" == 0 ]]
+  output=$(echo "$output" | paste -s -d ' ' -)
+  [[ "$output" =~ 'default' ]] || fail "output was: \"$output\""
+}
+
+@test "'vault policy-delete ' => default root" {
+  run get_completions 'vault policy-delete '
+  [[ "$status" == 0 ]]
+  output=$(echo "$output" | paste -s -d ' ' -)
+  [[ "$output" =~ 'default root' ]] || fail "output was: \"$output\""
+}
+
+@test "'vault policy-delete d' => default" {
+  run get_completions 'vault policy-delete d'
+  [[ "$status" == 0 ]]
+  output=$(echo "$output" | paste -s -d ' ' -)
+  [[ "$output" =~ 'default' ]] || fail "output was: \"$output\""
+}
+
+@test "'vault policy-write ' => default root" {
+  run get_completions 'vault policy-write '
+  [[ "$status" == 0 ]]
+  output=$(echo "$output" | paste -s -d ' ' -)
+  [[ "$output" =~ 'default root' ]] || fail "output was: \"$output\""
+}
+
+@test "'vault policy-write d' => default" {
+  run get_completions 'vault policy-write d'
+  [[ "$status" == 0 ]]
+  output=$(echo "$output" | paste -s -d ' ' -)
+  [[ "$output" =~ 'default' ]] || fail "output was: \"$output\""
+}


### PR DESCRIPTION
```
$ bats tests/tests.bats
Running "bats-exec-test" on "/Users/marca/dev/git-repos/vault-bash-completion/tests/tests.bats" ...
 ✓ 'vault ' => commands
 ✓ 'vault c' => commands
 ✓ 'vault p' => commands
 ✓ 'vault r' => commands
 ✓ 'vault read' => cubbyhole/ secret/ sys/
 ✓ 'vault read c' => cubbyhole/
 ✓ 'vault read s' => secret/ sys/
 ✓ 'vault list' => cubbyhole/ secret/ sys/
 ✓ 'vault list c' => cubbyhole/
 ✓ 'vault list s' => secret/ sys/
 ✓ 'vault list cubbyhole/' => cubbyhole/test
 ✓ 'vault policies ' => default root
 ✓ 'vault policies d' => default
 ✓ 'vault policy-delete ' => default root
 ✓ 'vault policy-delete d' => default
 ✓ 'vault policy-write ' => default root
 ✓ 'vault policy-write d' => default

17 tests, 0 failures
```