### PR TITLE
Dockerized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: bash
+sudo: required
+services:
+  - docker
+env:
+  - BASH_VERSION=4.4.5
+  - BASH_VERSION=3.2.57
+script: docker-compose -f tests/docker-compose.yml run test-vault-bash-completion-${BASH_VERSION}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for bash_version in 4.4.5 3.2.57; do
+  echo "*** Running tests for bash $bash_version ..."
+  docker-compose -f tests/docker-compose.yml run test-vault-bash-completion-$bash_version
+  echo
+done

--- a/tests/Dockerfile-bash-3.2.57
+++ b/tests/Dockerfile-bash-3.2.57
@@ -1,0 +1,11 @@
+FROM bash:3.2.57
+
+RUN apk update && apk add bash coreutils git openssl
+RUN git clone https://github.com/sstephenson/bats.git /tmp/bats
+RUN /tmp/bats/install.sh /usr/local
+RUN wget -O /tmp/vault_0.6.2_linux_amd64.zip https://releases.hashicorp.com/vault/0.6.2/vault_0.6.2_linux_amd64.zip && \
+    unzip -d /usr/local/bin /tmp/vault_0.6.2_linux_amd64.zip
+
+ADD . /app
+WORKDIR /app
+CMD bats tests/

--- a/tests/Dockerfile-bash-4.4.5
+++ b/tests/Dockerfile-bash-4.4.5
@@ -1,0 +1,11 @@
+FROM bash:4.4.5
+
+RUN apk update && apk add bash coreutils git openssl
+RUN git clone https://github.com/sstephenson/bats.git /tmp/bats && \
+    /tmp/bats/install.sh /usr/local
+RUN wget -O /tmp/vault_0.6.2_linux_amd64.zip https://releases.hashicorp.com/vault/0.6.2/vault_0.6.2_linux_amd64.zip && \
+    unzip -d /usr/local/bin /tmp/vault_0.6.2_linux_amd64.zip
+
+ADD . /app
+WORKDIR /app
+CMD bats tests/

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,34 @@
+---
+version: '2'
+services:
+
+  vault:
+    image: vault
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: 800f70d2-f5d0-f89d-592c-0dc57f090b7f
+
+  test-vault-bash-completion-4.4.5:
+    build:
+      context: ../
+      dockerfile: tests/Dockerfile-bash-4.4.5
+    volumes:
+      - ..:/app
+    links:
+      - vault
+    environment:
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: 800f70d2-f5d0-f89d-592c-0dc57f090b7f
+    tty: true
+
+  test-vault-bash-completion-3.2.57:
+    build:
+      context: ../
+      dockerfile: tests/Dockerfile-bash-3.2.57
+    volumes:
+      - ..:/app
+    links:
+      - vault
+    environment:
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: 800f70d2-f5d0-f89d-592c-0dc57f090b7f
+    tty: true

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -3,8 +3,6 @@
 source vault-bash-completion.sh
 load get_completions
 
-export VAULT_ADDR=http://127.0.0.1:8200
-
 fail() {
   echo "$@" > /dev/stderr
   return 1


### PR DESCRIPTION
This runs the tests (added in #6) using Docker and [Docker Compose](https://docs.docker.com/compose/). A dev Vault server is run in its own Docker container automatically (using the [vault Docker image](https://hub.docker.com/_/vault/)) and then the tests run in a bash container (using the [bash Docker image](https://hub.docker.com/_/bash/)) that is linked so that the bash container can access the Vault container.

This means that anyone should be able to run tests without even having Vault or [bats](https://github.com/sstephenson/bats) installed.

It's as simple as this for a person to run the tests:

```
$ ./run-tests.sh
*** Running tests for bash 4.4.5 ...
1..17
ok 1 'vault ' => commands
ok 2 'vault c' => commands
ok 3 'vault p' => commands
ok 4 'vault r' => commands
ok 5 'vault read' => cubbyhole/ secret/ sys/
ok 6 'vault read c' => cubbyhole/
ok 7 'vault read s' => secret/ sys/
ok 8 'vault list' => cubbyhole/ secret/ sys/
ok 9 'vault list c' => cubbyhole/
ok 10 'vault list s' => secret/ sys/
ok 11 'vault list cubbyhole/' => cubbyhole/test
ok 12 'vault policies ' => default root
ok 13 'vault policies d' => default
ok 14 'vault policy-delete ' => default root
ok 15 'vault policy-delete d' => default
ok 16 'vault policy-write ' => default root
ok 17 'vault policy-write d' => default

*** Running tests for bash 3.2.57 ...
1..17
ok 1 'vault ' => commands
ok 2 'vault c' => commands
ok 3 'vault p' => commands
ok 4 'vault r' => commands
ok 5 'vault read' => cubbyhole/ secret/ sys/
ok 6 'vault read c' => cubbyhole/
ok 7 'vault read s' => secret/ sys/
ok 8 'vault list' => cubbyhole/ secret/ sys/
ok 9 'vault list c' => cubbyhole/
ok 10 'vault list s' => secret/ sys/
ok 11 'vault list cubbyhole/' => cubbyhole/test
ok 12 'vault policies ' => default root
ok 13 'vault policies d' => default
ok 14 'vault policy-delete ' => default root
ok 15 'vault policy-delete d' => default
ok 16 'vault policy-write ' => default root
ok 17 'vault policy-write d' => default
```

Also, I added a `.travis.yml` file for Travis CI, which allows the tests to run in Travis CI. See https://travis-ci.org/msabramo/vault-bash-completion/builds/180991925 for an example (successful) test run.

[![Successful Travis CI run](https://cloud.githubusercontent.com/assets/305268/20861330/1261789e-b942-11e6-8918-e9f3bfbda8c0.png)](https://travis-ci.org/msabramo/vault-bash-completion/builds/180991925)