### PR TITLE
[WIP] Add space after vault commands

### DIFF
--- a/vault-bash-completion.sh
+++ b/vault-bash-completion.sh
@@ -33,11 +33,13 @@ function _vault() {
     COMPREPLY=($(compgen -W "$policies" -- $cur))
   elif [ "$(echo $line | wc -w)" -le 2 ]; then
     if [[ "$line" =~ ^vault\ (read|write|delete|list)\ $ ]]; then
+      compopt -o nospace
       COMPREPLY=($(compgen -W "$(_vault_mounts)" -- ''))
     else
       COMPREPLY=($(compgen -W "$VAULT_COMMANDS" -- $cur))
     fi
   elif [[ "$line" =~ ^vault\ (read|write|delete|list)\ (.*)$ ]]; then
+    compopt -o nospace
     path=${BASH_REMATCH[2]}
     if [[ "$path" =~ ^([^ ]+)/([^ /]*)$ ]]; then
       list=$(vault list -format=yaml ${BASH_REMATCH[1]} 2> /dev/null | awk '{ print $2 }')
@@ -48,4 +50,4 @@ function _vault() {
   fi
 }
 
-complete -o default -o nospace -F _vault vault
+complete -o default -F _vault vault


### PR DESCRIPTION
I am frustrating with the lack of auto spacing after main vault commands
e.x. after `vault rea[TAB]` i whant to see `vault read [CURSOR]` at current realisation we got `vault read[CURSOR]` which constrained us to input extra `space` instead of another `tab` for path suggestions
In bash i found [compopt](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html) which allow to set in function add extra `space` behavior.
But tests failed because `compopt: command not found`.
How it could be fix or there could be another implementation of this behavior??